### PR TITLE
fix: log error if peer dependency not met

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -2,5 +2,6 @@
 
 require('..').run()
   .catch(_error => {
+    console.error(_error.message)
     process.exitCode = 1;
   })


### PR DESCRIPTION
When I was setting up the commitlint-circle, I first couldn't figure out why the module is erroring out with `1`;
This should give some clarity.

After some reading I understand why you picked a peer dependency, but I am unsure since it's a dev dependency if it's worth overhead of debugging.